### PR TITLE
Add Docker build, CI workflow and documentation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,55 @@
+name: Build docker image
+
+on:
+  push:
+    branches: 
+      - main
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: 
+      - main
+   
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=true
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-alpine
+WORKDIR /app
+COPY requirements.txt .
+COPY *.py .
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python", "GTFS2NeTEx-converter.py"]

--- a/README-EN.md
+++ b/README-EN.md
@@ -174,7 +174,13 @@ If the conversion process ends correctly within the directory ```<GTFS_FEED_FOLD
 - ```<NUTS2_CODE>-<AGENCY_ACRONYM>-NeTEx_L1.xml.gz```: NeTEx Italian Profile Level 1 (gz-compressed)
 - ```<AGENCY_ACRONYM>.db```: Intermediate SQLite3 database used by the converter during processing; can be used for debugging purposes and processed later for further purposes (e.g. calculation of transportation KPIs related to the transportation offer described in the data); an effective cross-platform open source editor for SQLite is [DB Browser for SQLite](https://sqlitebrowser.org/) 
 
+## Run as docker container
+The application is also available as docker container (see packages on this repo)
 
+Make sure to mount your decompressed gtfs folder, and reference it as `<GTFS_FEED_FOLDER>` like so:
+```sh
+docker run --rm --volume ./gtfs:/gtfs  ghcr.io/liguria-digitale/gtfs2netex-converter:latest --folder /gtfs --NUTS <NUTS2_CODE> --db <AGENCY_ACRONYM> --az <AGENCY_ACRONYM> --vat <AGENCY_VAT_NUMBER> --version <VERSION_NAME>
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ Se il processo termina correttamente all'interno della directory ```<GTFS_FEED_F
 - ```<NUTS2_CODE>-<AGENCY_ACRONYM>-NeTEx_L1.xml.gz```: stesso file NeTEx Italian Profile Level 1 (in formato gz compresso)
 - ```<AGENCY_ACRONYM>.db```: database SQLite3 intermedio utilizzato dal convertitore durante l'elaborazione; puo' essere usato sia per scopi di debugging che elaborato successivamente per altre finalita' (es. calcolo KPI relativi all'offerta di trasporto descritta nei dati); un efficace editor multipiattaforma open source per SQLite è' [DB Browser for SQLite](https://sqlitebrowser.org/) 
 
+## Lanciare come docker container
+L'applicazione è anche disponibile in formato docker (vedi sezione packages)
 
-
-
-
----
+La cartella gtfs deve essere mountata come volume, e passata come `<GTFS_FEED_FOLDER>`:
+```sh
+docker run --rm --volume ./gtfs:/gtfs  ghcr.io/liguria-digitale/gtfs2netex-converter:latest --folder /gtfs --NUTS <NUTS2_CODE> --db <AGENCY_ACRONYM> --az <AGENCY_ACRONYM> --vat <AGENCY_VAT_NUMBER> --version <VERSION_NAME>
+```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+haversine==2.9.0
+numpy==2.2.0
+pandas==2.2.3
+python-dateutil==2.9.0.post0
+pytz==2024.2
+six==1.17.0
+tzdata==2024.2


### PR DESCRIPTION
Hi, we're considering using your converter for a project of ours.
We're relying heavily on docker, so I've packaged the application as a container and added a basic workflow to automatically build and publish the image.
I think this could benefit all users since they don't have to set up python or install dependencies manually anymore.

I've also added a `requirements.txt` file to pin dependencies, and allow install with a `pip install -r requirements.txt`. Maybe this could be added to the README as well.

Let me know if this can be of use to you, or if you have any feedback regarding the changes.

If you want to test the image first, you can use [our build](https://github.com/noi-techpark/GTFS2NeTEx-converter/pkgs/container/gtfs2netex-converter)