### PR TITLE
Fix poinsInSequence missing when pickup_type or drop_off_type in stop_times.txt are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# vscode
+.vscode

--- a/CreateLoadDBComponent.py
+++ b/CreateLoadDBComponent.py
@@ -1135,7 +1135,7 @@ class StartImportProcess():
                   AS
                   SELECT 
                   trip_id,
-                  (MIN(stop_sequence) || "-" || MAX(stop_sequence) || "-" || COUNT(stop_id) || "-" || SUM(pickup_type) || "-" || SUM(drop_off_type)) AS space_patt FROM tb_stop_times GROUP BY trip_id ORDER BY trip_id''')
+                  (MIN(stop_sequence) || "-" || MAX(stop_sequence) || "-" || COUNT(stop_id) || "-" || SUM(COALESCE(pickup_type,'0')) || "-" || SUM(COALESCE(drop_off_type,'0'))) AS space_patt FROM tb_stop_times GROUP BY trip_id ORDER BY trip_id''')
 
     conn.commit()
 


### PR DESCRIPTION
We've encountered a bug with our GTFS files that has empty `pickup_type` and `drop_off_type` in stop_times.txt:
The converter, without giving any errors, did not generate any `ServiceFrame/journeyPatterns/ServiceJourneyPattern/pointsInSequence` records. 

According to [the GTFS spec](https://gtfs.org/documentation/schedule/reference/#stop_timestxt) these fields are optional, and empty corresponds to `0`.

This is our GTFS file in case you want to reproduce:
[skyalps-flight-data.zip](https://github.com/user-attachments/files/18866121/skyalps-flight-data.5.zip)

The issue was due to a query not being null-safe, I've wrapped the relevant fields with a `COALESCE` that should handle null values correctly.

Also added a basic .gitignore file
